### PR TITLE
Refactor sidebar navigation handler

### DIFF
--- a/Views/Sidebar.xaml
+++ b/Views/Sidebar.xaml
@@ -43,7 +43,7 @@
                             <Trigger Property="IsMouseOver" Value="True">
                                 <Setter TargetName="Pill" Property="Background" Value="#EFF6FF"/>
                             </Trigger>
-                            <Trigger Property="Tag" Value="active">
+                            <Trigger Property="Uid" Value="active">
                                 <Setter TargetName="Pill" Property="Background" Value="#2563EB"/>
                                 <Setter Property="Foreground" Value="White"/>
                                 <Setter TargetName="Pill" Property="Effect">
@@ -84,49 +84,49 @@
             <!-- Menú -->
             <StackPanel x:Name="MenuStack" Margin="16,10,16,0">
 
-                <Button x:Name="BtnDashboard" Style="{StaticResource SidebarNavButton}" Click="Dashboard_Click" Tag="active">
+                <Button x:Name="BtnDashboard" Style="{StaticResource SidebarNavButton}" Click="Menu_Click" Tag="Dashboard" Uid="active">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{StaticResource SidebarIcon}" Text="&#xE80F;"/>
                         <TextBlock Text="Dashboard"/>
                     </StackPanel>
                 </Button>
 
-                <Button x:Name="BtnOrders" Style="{StaticResource SidebarNavButton}" Click="Orders_Click">
+                <Button x:Name="BtnOrders" Style="{StaticResource SidebarNavButton}" Click="Menu_Click" Tag="Orders">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{StaticResource SidebarIcon}" Text="&#xE7BF;"/>
                         <TextBlock Text="Pedidos"/>
                     </StackPanel>
                 </Button>
 
-                <Button x:Name="BtnClients" Style="{StaticResource SidebarNavButton}" Click="Clients_Click">
+                <Button x:Name="BtnClients" Style="{StaticResource SidebarNavButton}" Click="Menu_Click" Tag="Clients">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{StaticResource SidebarIcon}" Text="&#xE77B;"/>
                         <TextBlock Text="Clientes"/>
                     </StackPanel>
                 </Button>
 
-                <Button x:Name="BtnProducts" Style="{StaticResource SidebarNavButton}" Click="Products_Click">
+                <Button x:Name="BtnProducts" Style="{StaticResource SidebarNavButton}" Click="Menu_Click" Tag="Products">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{StaticResource SidebarIcon}" Text="&#xE719;"/>
                         <TextBlock Text="Productos"/>
                     </StackPanel>
                 </Button>
 
-                <Button x:Name="BtnProviders" Style="{StaticResource SidebarNavButton}" Click="Providers_Click">
+                <Button x:Name="BtnProviders" Style="{StaticResource SidebarNavButton}" Click="Menu_Click" Tag="Providers">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{StaticResource SidebarIcon}" Text="&#xE7FC;"/>
                         <TextBlock Text="Proveedores"/>
                     </StackPanel>
                 </Button>
 
-                <Button x:Name="BtnCash" Style="{StaticResource SidebarNavButton}" Click="Cash_Click">
+                <Button x:Name="BtnCash" Style="{StaticResource SidebarNavButton}" Click="Menu_Click" Tag="Cash">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{StaticResource SidebarIcon}" Text="&#xE719;"/>
                         <TextBlock Text="Caja"/>
                     </StackPanel>
                 </Button>
 
-                <Button x:Name="BtnReports" Style="{StaticResource SidebarNavButton}" Click="Reports_Click">
+                <Button x:Name="BtnReports" Style="{StaticResource SidebarNavButton}" Click="Menu_Click" Tag="Reports">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{StaticResource SidebarIcon}" Text="&#xE9D9;"/>
                         <TextBlock Text="Reportes"/>

--- a/Views/Sidebar.xaml.cs
+++ b/Views/Sidebar.xaml.cs
@@ -13,55 +13,21 @@ namespace ToxicBizBuddyWPF.Views
         }
 
         // Navegación: llamamos al método público del MainWindow
-        private void Dashboard_Click(object sender, RoutedEventArgs e)
+        private void Menu_Click(object sender, RoutedEventArgs e)
         {
-            SetActive((Button)sender);
-            (Application.Current.MainWindow as MainWindow)?.NavigateTo("Dashboard");
-        }
-
-        private void Orders_Click(object sender, RoutedEventArgs e)
-        {
-            SetActive((Button)sender);
-            (Application.Current.MainWindow as MainWindow)?.NavigateTo("Orders");
-        }
-
-        private void Clients_Click(object sender, RoutedEventArgs e)
-        {
-            SetActive((Button)sender);
-            (Application.Current.MainWindow as MainWindow)?.NavigateTo("Clients");
-        }
-
-        private void Products_Click(object sender, RoutedEventArgs e)
-        {
-            SetActive((Button)sender);
-            (Application.Current.MainWindow as MainWindow)?.NavigateTo("Products");
-        }
-
-        private void Providers_Click(object sender, RoutedEventArgs e)
-        {
-            SetActive((Button)sender);
-            (Application.Current.MainWindow as MainWindow)?.NavigateTo("Providers");
-        }
-
-        private void Cash_Click(object sender, RoutedEventArgs e)
-        {
-            SetActive((Button)sender);
-            (Application.Current.MainWindow as MainWindow)?.NavigateTo("Cash");
-        }
-
-        private void Reports_Click(object sender, RoutedEventArgs e)
-        {
-            SetActive((Button)sender);
-            (Application.Current.MainWindow as MainWindow)?.NavigateTo("Reports");
+            var button = (Button)sender;
+            var route = button.Tag as string;
+            (Application.Current.MainWindow as MainWindow)?.NavigateTo(route);
+            SetActive(button);
         }
 
         // Visual activo
         private void SetActive(Button activeButton)
         {
             foreach (var btn in MenuStack.Children.OfType<Button>())
-                btn.Tag = null;
+                btn.Uid = null;
 
-            activeButton.Tag = "active";
+            activeButton.Uid = "active";
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace individual sidebar click handlers with a single method that reads target from `Tag`
- reuse `Uid` for active styling and update `SetActive`
- unify XAML buttons to share the same click handler and tag their destinations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84083f92c8327868714f9d24fab1a