### PR TITLE
Use typed order fields with formatted bindings

### DIFF
--- a/Converters/ItemsToStringConverter.cs
+++ b/Converters/ItemsToStringConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ToxicBizBuddyWPF.Converters
+{
+    public sealed class ItemsToStringConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is int count)
+                return count == 1 ? "1 item" : $"{count} items";
+            return null;
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+            => Binding.DoNothing;
+    }
+}

--- a/Views/OrdersPage.xaml
+++ b/Views/OrdersPage.xaml
@@ -1,10 +1,12 @@
-﻿<Page x:Class="ToxicBizBuddyWPF.Views.OrdersPage" 
+﻿<Page x:Class="ToxicBizBuddyWPF.Views.OrdersPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components"
+      xmlns:conv="clr-namespace:ToxicBizBuddyWPF.Converters"
       Title="Gestión de Pedidos">
 
     <Page.Resources>
+        <conv:ItemsToStringConverter x:Key="ItemsToStringConverter"/>
 
         <!-- Card -->
         <Style x:Key="CardStyle" TargetType="Border">
@@ -356,7 +358,7 @@
                             <DataGridTemplateColumn Header="Fecha" Width="*" MinWidth="110" HeaderStyle="{StaticResource CenterHeader}">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
-                                        <TextBlock Text="{Binding Fecha}" FontSize="14"
+                                        <TextBlock Text="{Binding Fecha, StringFormat='{}{0:yyyy-MM-dd}'}" FontSize="14"
                                                    Foreground="#64748B" TextAlignment="Center"
                                                    VerticalAlignment="Center"/>
                                     </DataTemplate>
@@ -366,7 +368,7 @@
                             <DataGridTemplateColumn Header="Items" Width="*" MinWidth="90" HeaderStyle="{StaticResource CenterHeader}">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
-                                        <TextBlock Text="{Binding Items}" FontSize="14"
+                                        <TextBlock Text="{Binding Items, Converter={StaticResource ItemsToStringConverter}}" FontSize="14"
                                                    TextAlignment="Center" VerticalAlignment="Center"
                                                    TextTrimming="CharacterEllipsis"/>
                                     </DataTemplate>
@@ -389,7 +391,7 @@
                             <DataGridTemplateColumn Header="Total" Width="*" MinWidth="130" HeaderStyle="{StaticResource CenterHeader}">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
-                                        <TextBlock Text="{Binding Total}" FontWeight="SemiBold" FontSize="14"
+                                        <TextBlock Text="{Binding Total, StringFormat='{}{0:$0.00}'}" FontWeight="SemiBold" FontSize="14"
                                                    TextAlignment="Center" VerticalAlignment="Center" Margin="8,0,0,0"/>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>

--- a/Views/OrdersPage.xaml.cs
+++ b/Views/OrdersPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -82,18 +81,18 @@ namespace ToxicBizBuddyWPF.Views
     {
         public string Pedido { get; }
         public string Cliente { get; }
-        public string Fecha { get; }
-        public string Items { get; }
-        public string Total { get; }
+        public DateTime Fecha { get; }
+        public int Items { get; }
+        public decimal Total { get; }
         public string Estado { get; }
 
         public OrderRow(string pedido, string cliente, DateTime fecha, int items, decimal total, string estado)
         {
             Pedido = pedido;
             Cliente = cliente;
-            Fecha = fecha.ToString("yyyy-MM-dd");
-            Items = items == 1 ? "1 item" : $"{items} items";
-            Total = total.ToString("$0.00", CultureInfo.InvariantCulture);
+            Fecha = fecha;
+            Items = items;
+            Total = total;
             Estado = estado; // "Completado" | "Pendiente" | "Cancelado"
         }
     }


### PR DESCRIPTION
## Summary
- Change `OrderRow` to expose `DateTime`/`int`/`decimal` properties and store raw values
- Add `ItemsToStringConverter` and apply formatted bindings with `StringFormat` and converter usage

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b842e7ce388327baae350d8c9bcb96