### PR TITLE
refactor: centralize metric card styles

### DIFF
--- a/Resources/MetricStyles.xaml
+++ b/Resources/MetricStyles.xaml
@@ -1,0 +1,49 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Tarjeta métrica base -->
+    <Style x:Key="MetricCard" TargetType="Border" BasedOn="{StaticResource CardStyle}">
+        <Setter Property="Padding" Value="16"/>
+        <Setter Property="CornerRadius" Value="12"/>
+        <Setter Property="BorderBrush" Value="#E5E7F0"/>
+        <Setter Property="Background" Value="#FFFFFF"/>
+    </Style>
+
+    <!-- Métrica amarilla (Stock Bajo) -->
+    <Style x:Key="MetricCardWarn" TargetType="Border" BasedOn="{StaticResource MetricCard}">
+        <Setter Property="Background">
+            <Setter.Value>
+                <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                    <GradientStop Color="#FFF7E6" Offset="0"/>
+                    <GradientStop Color="#FFFDF6" Offset="1"/>
+                </LinearGradientBrush>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="BorderBrush" Value="#FDE68A"/>
+    </Style>
+
+    <!-- Métrica roja (Stock Crítico) -->
+    <Style x:Key="MetricCardDanger" TargetType="Border" BasedOn="{StaticResource MetricCard}">
+        <Setter Property="Background">
+            <Setter.Value>
+                <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                    <GradientStop Color="#FEE2E2" Offset="0"/>
+                    <GradientStop Color="#FFF5F5" Offset="1"/>
+                </LinearGradientBrush>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="BorderBrush" Value="#F9C3C3"/>
+    </Style>
+
+    <!-- Métrica verde (Valor Inventario) -->
+    <Style x:Key="MetricCardSuccess" TargetType="Border" BasedOn="{StaticResource MetricCard}">
+        <Setter Property="Background">
+            <Setter.Value>
+                <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                    <GradientStop Color="#E8FBEF" Offset="0"/>
+                    <GradientStop Color="#F4FFF9" Offset="1"/>
+                </LinearGradientBrush>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="BorderBrush" Value="#D6F5E2"/>
+    </Style>
+</ResourceDictionary>

--- a/Views/ClientsPage.xaml
+++ b/Views/ClientsPage.xaml
@@ -9,48 +9,20 @@
 
     <!-- Estilos locales de esta página -->
     <Page.Resources>
-        <!-- Tarjeta métrica base -->
-        <Style x:Key="MetricCard" TargetType="Border" BasedOn="{StaticResource CardStyle}">
-            <Setter Property="Padding" Value="16"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="BorderBrush" Value="#E5E7F0"/>
-            <Setter Property="Background" Value="#FFFFFF"/>
-        </Style>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Resources/MetricStyles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
 
-        <!-- Métrica verde (Saldo a favor) -->
-        <Style x:Key="MetricCardSuccess" TargetType="Border" BasedOn="{StaticResource MetricCard}">
-            <Setter Property="Background">
-                <Setter.Value>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                        <GradientStop Color="#E8FBEF" Offset="0"/>
-                        <GradientStop Color="#F4FFF9" Offset="1"/>
-                    </LinearGradientBrush>
-                </Setter.Value>
-            </Setter>
-            <Setter Property="BorderBrush" Value="#D6F5E2"/>
-        </Style>
-
-        <!-- Métrica roja (Deudas) -->
-        <Style x:Key="MetricCardDanger" TargetType="Border" BasedOn="{StaticResource MetricCard}">
-            <Setter Property="Background">
-                <Setter.Value>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                        <GradientStop Color="#FEECEC" Offset="0"/>
-                        <GradientStop Color="#FFF5F5" Offset="1"/>
-                    </LinearGradientBrush>
-                </Setter.Value>
-            </Setter>
-            <Setter Property="BorderBrush" Value="#F9D3D3"/>
-        </Style>
-
-        <!-- Burbuja de icono dentro de las métricas -->
-        <Style x:Key="MetricIconPill" TargetType="Border">
-            <Setter Property="CornerRadius" Value="999"/>
-            <Setter Property="Background" Value="#EEF2FF"/>
-            <Setter Property="Padding" Value="10"/>
-            <Setter Property="HorizontalAlignment" Value="Right"/>
-            <Setter Property="VerticalAlignment" Value="Top"/>
-        </Style>
+            <!-- Burbuja de icono dentro de las métricas -->
+            <Style x:Key="MetricIconPill" TargetType="Border">
+                <Setter Property="CornerRadius" Value="999"/>
+                <Setter Property="Background" Value="#EEF2FF"/>
+                <Setter Property="Padding" Value="10"/>
+                <Setter Property="HorizontalAlignment" Value="Right"/>
+                <Setter Property="VerticalAlignment" Value="Top"/>
+            </Style>
+        </ResourceDictionary>
     </Page.Resources>
 
     <components:PageWrapper>

--- a/Views/ProductsPage.xaml
+++ b/Views/ProductsPage.xaml
@@ -6,61 +6,20 @@
 
     <!-- Estilos locales de esta página -->
     <Page.Resources>
-        <!-- Tarjeta métrica base -->
-        <Style x:Key="MetricCard" TargetType="Border" BasedOn="{StaticResource CardStyle}">
-            <Setter Property="Padding" Value="16"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="BorderBrush" Value="#E5E7F0"/>
-            <Setter Property="Background" Value="#FFFFFF"/>
-        </Style>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Resources/MetricStyles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
 
-        <!-- Métrica amarilla (Stock Bajo) -->
-        <Style x:Key="MetricCardWarn" TargetType="Border" BasedOn="{StaticResource MetricCard}">
-            <Setter Property="Background">
-                <Setter.Value>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                        <GradientStop Color="#FFF7E6" Offset="0"/>
-                        <GradientStop Color="#FFFDF6" Offset="1"/>
-                    </LinearGradientBrush>
-                </Setter.Value>
-            </Setter>
-            <Setter Property="BorderBrush" Value="#FDE68A"/>
-        </Style>
-
-        <!-- Métrica roja (Stock Crítico) -->
-        <Style x:Key="MetricCardDanger" TargetType="Border" BasedOn="{StaticResource MetricCard}">
-            <Setter Property="Background">
-                <Setter.Value>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                        <GradientStop Color="#FEE2E2" Offset="0"/>
-                        <GradientStop Color="#FFF5F5" Offset="1"/>
-                    </LinearGradientBrush>
-                </Setter.Value>
-            </Setter>
-            <Setter Property="BorderBrush" Value="#F9C3C3"/>
-        </Style>
-
-        <!-- Métrica verde (Valor Inventario) -->
-        <Style x:Key="MetricCardSuccess" TargetType="Border" BasedOn="{StaticResource MetricCard}">
-            <Setter Property="Background">
-                <Setter.Value>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                        <GradientStop Color="#E8FBEF" Offset="0"/>
-                        <GradientStop Color="#F4FFF9" Offset="1"/>
-                    </LinearGradientBrush>
-                </Setter.Value>
-            </Setter>
-            <Setter Property="BorderBrush" Value="#D6F5E2"/>
-        </Style>
-
-        <!-- Burbuja de icono dentro de las métrricas -->
-        <Style x:Key="MetricIconPill" TargetType="Border">
-            <Setter Property="CornerRadius" Value="999"/>
-            <Setter Property="Background" Value="#EEF2FF"/>
-            <Setter Property="Padding" Value="10"/>
-            <Setter Property="HorizontalAlignment" Value="Right"/>
-            <Setter Property="VerticalAlignment" Value="Top"/>
-        </Style>
+            <!-- Burbuja de icono dentro de las métrricas -->
+            <Style x:Key="MetricIconPill" TargetType="Border">
+                <Setter Property="CornerRadius" Value="999"/>
+                <Setter Property="Background" Value="#EEF2FF"/>
+                <Setter Property="Padding" Value="10"/>
+                <Setter Property="HorizontalAlignment" Value="Right"/>
+                <Setter Property="VerticalAlignment" Value="Top"/>
+            </Style>
+        </ResourceDictionary>
     </Page.Resources>
 
     <components:PageWrapper>


### PR DESCRIPTION
## Summary
- create shared `MetricStyles.xaml` with metric card variants
- use shared metric styles on product and client pages

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8450e54308327abe4039c32b3d9f9