### PR TITLE
refactor: centralize dialog layout

### DIFF
--- a/Views/Dialogs/AddClientDialog.xaml
+++ b/Views/Dialogs/AddClientDialog.xaml
@@ -1,156 +1,122 @@
-﻿<Window x:Class="ToxicBizBuddyWPF.Views.Dialogs.AddClientDialog"
+<dialogs:DialogBase x:Class="ToxicBizBuddyWPF.Views.Dialogs.AddClientDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="clr-namespace:ToxicBizBuddyWPF.Views.Dialogs"
         Title="Agregar cliente"
-        WindowStyle="None"
-        ResizeMode="NoResize"
-        AllowsTransparency="True"
-        Background="Transparent"
-        WindowStartupLocation="CenterOwner"
-        WindowState="Maximized"
-        ShowInTaskbar="False"
-        Topmost="True">
+        CardWidth="640">
+    <StackPanel>
+        <!-- Formulario -->
+        <Grid Margin="0,8,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <!-- Nombre -->
+                <RowDefinition Height="Auto"/>
+                <!-- Tipo cliente / Documento -->
+                <RowDefinition Height="Auto"/>
+                <!-- Teléfono / Email -->
+                <RowDefinition Height="Auto"/>
+                <!-- Dirección / Localidad -->
+                <RowDefinition Height="Auto"/>
+                <!-- Provincia / Condición de pago -->
+                <RowDefinition Height="Auto"/>
+                <!-- Límite crédito / Descuento -->
+                <RowDefinition Height="Auto"/>
+                <!-- Observaciones -->
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
 
-    <Grid Background="#80000000">
-        <Border Style="{StaticResource CardStyle}" Width="640" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <StackPanel>
-
-                <!-- Header -->
-                <Grid Margin="0,0,0,12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Text="Agregar cliente" Style="{StaticResource H1}" FontSize="20" VerticalAlignment="Center"/>
-                    <Button Grid.Column="1"
-                  Content="✕"
-                  Width="34" Height="34"
-                  Background="Transparent"
-                  BorderThickness="0"
-                  Cursor="Hand"
-                  HorizontalAlignment="Right"
-                  ToolTip="Cerrar"
-                  Click="Close_Click"/>
-                </Grid>
-
-                <!-- Formulario -->
-                <Grid Margin="0,8,0,0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <!-- Nombre -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Tipo cliente / Documento -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Teléfono / Email -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Dirección / Localidad -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Provincia / Condición de pago -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Límite crédito / Descuento -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Observaciones -->
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <!-- Nombre / Razón social -->
-                    <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,10">
-                        <TextBlock Text="Nombre / Razón social" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Campo obligatorio"/>
-                    </StackPanel>
-
-                    <!-- Tipo de cliente -->
-                    <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Tipo de cliente" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
-                            <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2">
-                                <ComboBoxItem Content="Seleccionar..." IsSelected="True"/>
-                                <ComboBoxItem Content="Consumidor final"/>
-                                <ComboBoxItem Content="Empresa"/>
-                                <ComboBoxItem Content="Revendedor"/>
-                            </ComboBox>
-                        </Border>
-                    </StackPanel>
-
-                    <!-- Documento -->
-                    <StackPanel Grid.Row="1" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Documento (DNI/CUIT)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}"/>
-                    </StackPanel>
-
-                    <!-- Teléfono -->
-                    <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Teléfono" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Preferible celular"/>
-                    </StackPanel>
-
-                    <!-- Email -->
-                    <StackPanel Grid.Row="2" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Email" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}"/>
-                    </StackPanel>
-
-                    <!-- Dirección -->
-                    <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Dirección (calle, número)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}"/>
-                    </StackPanel>
-
-                    <!-- Localidad -->
-                    <StackPanel Grid.Row="3" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Localidad" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}"/>
-                    </StackPanel>
-
-                    <!-- Provincia -->
-                    <StackPanel Grid.Row="4" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Provincia" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}"/>
-                    </StackPanel>
-
-                    <!-- Condición de pago -->
-                    <StackPanel Grid.Row="4" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Condición de pago" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
-                            <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2">
-                                <ComboBoxItem Content="Contado" IsSelected="True"/>
-                                <ComboBoxItem Content="Crédito"/>
-                            </ComboBox>
-                        </Border>
-                    </StackPanel>
-
-                    <!-- Límite de crédito -->
-                    <StackPanel Grid.Row="5" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Límite de crédito" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Si aplica"/>
-                    </StackPanel>
-
-                    <!-- Descuento (%) -->
-                    <StackPanel Grid.Row="5" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Descuento (%)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Si aplica"/>
-                    </StackPanel>
-
-                    <!-- Observaciones -->
-                    <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Margin="0,0,0,0">
-                        <TextBlock Text="Observaciones" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" Height="60" TextWrapping="Wrap" AcceptsReturn="True"/>
-                    </StackPanel>
-
-                </Grid>
-
-                <!-- Footer -->
-                <!-- Footer -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
-                    <Button Content="Cancelar" Style="{StaticResource BtnGhost}" Click="Close_Click"/>
-                    <Button Content="Guardar"  Style="{StaticResource BtnPrimary}" Margin="12,0,0,0" Click="Save_Click"/>
-                </StackPanel>
-
-
+            <!-- Nombre / Razón social -->
+            <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,10">
+                <TextBlock Text="Nombre / Razón social" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Campo obligatorio"/>
             </StackPanel>
-        </Border>
-    </Grid>
-</Window>
+
+            <!-- Tipo de cliente -->
+            <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Tipo de cliente" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
+                    <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2">
+                        <ComboBoxItem Content="Seleccionar..." IsSelected="True"/>
+                        <ComboBoxItem Content="Consumidor final"/>
+                        <ComboBoxItem Content="Empresa"/>
+                        <ComboBoxItem Content="Revendedor"/>
+                    </ComboBox>
+                </Border>
+            </StackPanel>
+
+            <!-- Documento -->
+            <StackPanel Grid.Row="1" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Documento (DNI/CUIT)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}"/>
+            </StackPanel>
+
+            <!-- Teléfono -->
+            <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Teléfono" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Preferible celular"/>
+            </StackPanel>
+
+            <!-- Email -->
+            <StackPanel Grid.Row="2" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Email" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}"/>
+            </StackPanel>
+
+            <!-- Dirección -->
+            <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Dirección (calle, número)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}"/>
+            </StackPanel>
+
+            <!-- Localidad -->
+            <StackPanel Grid.Row="3" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Localidad" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}"/>
+            </StackPanel>
+
+            <!-- Provincia -->
+            <StackPanel Grid.Row="4" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Provincia" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}"/>
+            </StackPanel>
+
+            <!-- Condición de pago -->
+            <StackPanel Grid.Row="4" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Condición de pago" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
+                    <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2">
+                        <ComboBoxItem Content="Contado" IsSelected="True"/>
+                        <ComboBoxItem Content="Crédito"/>
+                    </ComboBox>
+                </Border>
+            </StackPanel>
+
+            <!-- Límite de crédito -->
+            <StackPanel Grid.Row="5" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Límite de crédito" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Si aplica"/>
+            </StackPanel>
+
+            <!-- Descuento (%) -->
+            <StackPanel Grid.Row="5" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Descuento (%)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Si aplica"/>
+            </StackPanel>
+
+            <!-- Observaciones -->
+            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Margin="0,0,0,0">
+                <TextBlock Text="Observaciones" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" Height="60" TextWrapping="Wrap" AcceptsReturn="True"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Footer -->
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
+            <Button Content="Cancelar" Style="{StaticResource BtnGhost}" Click="Close_Click"/>
+            <Button Content="Guardar"  Style="{StaticResource BtnPrimary}" Margin="12,0,0,0" Click="Save_Click"/>
+        </StackPanel>
+    </StackPanel>
+</dialogs:DialogBase>

--- a/Views/Dialogs/AddClientDialog.xaml.cs
+++ b/Views/Dialogs/AddClientDialog.xaml.cs
@@ -1,18 +1,12 @@
-﻿using System.Windows;
+using System.Windows;
 
 namespace ToxicBizBuddyWPF.Views.Dialogs
 {
-    public partial class AddClientDialog : Window
+    public partial class AddClientDialog : DialogBase
     {
         public AddClientDialog()
         {
             InitializeComponent();
-        }
-
-        private void Close_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = false;
-            Close();
         }
 
         private void Save_Click(object sender, RoutedEventArgs e)

--- a/Views/Dialogs/AddProductDialog.xaml
+++ b/Views/Dialogs/AddProductDialog.xaml
@@ -1,156 +1,111 @@
-﻿<Window x:Class="ToxicBizBuddyWPF.Views.Dialogs.AddProductDialog"
+<dialogs:DialogBase x:Class="ToxicBizBuddyWPF.Views.Dialogs.AddProductDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:dialogs="clr-namespace:ToxicBizBuddyWPF.Views.Dialogs"
         Title="Agregar producto"
-        WindowStyle="None"
-        ResizeMode="NoResize"
-        AllowsTransparency="True"
-        Background="Transparent"
-        WindowStartupLocation="CenterOwner"
-        WindowState="Maximized"
-        ShowInTaskbar="False"
-        Topmost="True">
+        CardWidth="640">
+    <StackPanel>
+        <!-- Formulario -->
+        <Grid Margin="0,8,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <!-- Nombre -->
+                <RowDefinition Height="Auto"/>
+                <!-- Categoria / Proveedor -->
+                <RowDefinition Height="Auto"/>
+                <!-- Precio compra / Precio venta -->
+                <RowDefinition Height="Auto"/>
+                <!-- Stock inicial / Estado -->
+                <RowDefinition Height="Auto"/>
+                <!-- SKU -->
+                <RowDefinition Height="Auto"/>
+                <!-- Vencimiento + checkbox -->
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
 
-    <!-- Overlay -->
-    <Grid Background="#80000000">
-        <!-- Card centrada -->
-        <Border Style="{StaticResource CardStyle}" Width="640" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <StackPanel>
-
-                <!-- Header (título + cerrar) -->
-                <Grid Margin="0,0,0,12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Text="Agregar producto" Style="{StaticResource H1}" FontSize="20" VerticalAlignment="Center"/>
-                    <Button Grid.Column="1"
-                  Content="✕"
-                  Width="34" Height="34"
-                  Background="Transparent"
-                  BorderThickness="0"
-                  Cursor="Hand"
-                  HorizontalAlignment="Right"
-                  ToolTip="Cerrar"
-                  Click="Close_Click"/>
-                </Grid>
-
-                <!-- Formulario -->
-                <Grid Margin="0,8,0,0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <!-- Nombre -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Categoria / Proveedor -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Precio compra / Precio venta -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Stock inicial / Estado -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- SKU -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Vencimiento + checkbox -->
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <!-- Nombre -->
-                    <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,10">
-                        <TextBlock Text="Nombre" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Nombre del producto"/>
-                    </StackPanel>
-
-                    <!-- Categoría -->
-                    <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Categoría" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
-                            <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2" ToolTip="Categoría del producto">
-                                <ComboBoxItem Content="Seleccionar..." IsSelected="True"/>
-                                <ComboBoxItem Content="Líquidos"/>
-                                <ComboBoxItem Content="Polvos"/>
-                                <ComboBoxItem Content="Desinfectantes"/>
-                                <ComboBoxItem Content="Accesorios"/>
-                            </ComboBox>
-                        </Border>
-                    </StackPanel>
-
-                    <!-- Proveedor (opcional si gestionás compras) -->
-                    <StackPanel Grid.Row="1" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Proveedor (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
-                            <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2" ToolTip="Proveedor (si gestionás compras)">
-                                <ComboBoxItem Content="— Ninguno —" IsSelected="True"/>
-                                <ComboBoxItem Content="Proveedor A"/>
-                                <ComboBoxItem Content="Proveedor B"/>
-                            </ComboBox>
-                        </Border>
-                    </StackPanel>
-
-                    <!-- Precio de compra -->
-                    <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Precio de compra" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Costo de compra (número)"/>
-                    </StackPanel>
-
-                    <!-- Precio de venta -->
-                    <StackPanel Grid.Row="2" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Precio de venta" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Precio de venta (número)"/>
-                    </StackPanel>
-
-                    <!-- Stock inicial -->
-                    <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Stock inicial" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Stock inicial (puede ser 0)"/>
-                    </StackPanel>
-
-                    <!-- Estado -->
-                    <StackPanel Grid.Row="3" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Estado" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
-                            <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2" ToolTip="Estado del producto">
-                                <ComboBoxItem Content="Activo" IsSelected="True"/>
-                                <ComboBoxItem Content="Inactivo"/>
-                            </ComboBox>
-                        </Border>
-                    </StackPanel>
-
-                    <!-- Código de barras / SKU -->
-                    <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Margin="0,0,0,10">
-                        <TextBlock Text="Código de barras / SKU" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Código único si existe"/>
-                    </StackPanel>
-
-                    <!-- Fecha de vencimiento -->
-                    <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Margin="0,0,0,0">
-                        <TextBlock Text="Fecha de vencimiento (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <StackPanel Orientation="Horizontal">
-                            <DatePicker x:Name="ExpiryDatePicker"
-                          SelectedDateFormat="Short"
-                          ToolTip="Debe ser futura si se informa"
-                          Width="180"/>
-                            <CheckBox x:Name="NoExpiryCheck"
-                        Content="Sin vencimiento"
-                        Margin="12,0,0,0"
-                        VerticalAlignment="Center"
-                        Checked="NoExpiryCheck_Changed"
-                        Unchecked="NoExpiryCheck_Changed"/>
-                        </StackPanel>
-                    </StackPanel>
-
-                </Grid>
-
-                <!-- Footer -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
-                    <Button Content="Cancelar" Style="{StaticResource BtnGhost}" Click="Close_Click"/>
-                    <Button Content="Guardar"  Style="{StaticResource BtnPrimary}" Margin="12,0,0,0" Click="Save_Click"/>
-                </StackPanel>
-
-
+            <!-- Nombre -->
+            <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,10">
+                <TextBlock Text="Nombre" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Nombre del producto"/>
             </StackPanel>
-        </Border>
-    </Grid>
-</Window>
+
+            <!-- Categoría -->
+            <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Categoría" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
+                    <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2" ToolTip="Categoría del producto">
+                        <ComboBoxItem Content="Seleccionar..." IsSelected="True"/>
+                        <ComboBoxItem Content="Líquidos"/>
+                        <ComboBoxItem Content="Polvos"/>
+                        <ComboBoxItem Content="Desinfectantes"/>
+                        <ComboBoxItem Content="Accesorios"/>
+                    </ComboBox>
+                </Border>
+            </StackPanel>
+
+            <!-- Proveedor (opcional si gestionás compras) -->
+            <StackPanel Grid.Row="1" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Proveedor (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
+                    <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2" ToolTip="Proveedor (si gestionás compras)">
+                        <ComboBoxItem Content="— Ninguno —" IsSelected="True"/>
+                        <ComboBoxItem Content="Proveedor A"/>
+                        <ComboBoxItem Content="Proveedor B"/>
+                    </ComboBox>
+                </Border>
+            </StackPanel>
+
+            <!-- Precio de compra -->
+            <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Precio de compra" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Costo de compra (número)"/>
+            </StackPanel>
+
+            <!-- Precio de venta -->
+            <StackPanel Grid.Row="2" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Precio de venta" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Precio de venta (número)"/>
+            </StackPanel>
+
+            <!-- Stock inicial -->
+            <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Stock inicial" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Stock inicial (puede ser 0)"/>
+            </StackPanel>
+
+            <!-- Estado -->
+            <StackPanel Grid.Row="3" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Estado" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
+                    <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2" ToolTip="Estado del producto">
+                        <ComboBoxItem Content="Activo" IsSelected="True"/>
+                        <ComboBoxItem Content="Inactivo"/>
+                    </ComboBox>
+                </Border>
+            </StackPanel>
+
+            <!-- SKU -->
+            <StackPanel Grid.Row="4" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="SKU (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Identificador de stock"/>
+            </StackPanel>
+
+            <!-- Vencimiento -->
+            <StackPanel Grid.Row="4" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Fecha de vencimiento" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <DatePicker x:Name="ExpiryDatePicker" Style="{StaticResource InputDate}"/>
+                <CheckBox x:Name="NoExpiryCheck" Content="Sin vencimiento" Margin="0,4,0,0" Checked="NoExpiryCheck_Changed" Unchecked="NoExpiryCheck_Changed"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Footer -->
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
+            <Button Content="Cancelar" Style="{StaticResource BtnGhost}" Click="Close_Click"/>
+            <Button Content="Guardar" Style="{StaticResource BtnPrimary}" Margin="12,0,0,0" Click="Save_Click"/>
+        </StackPanel>
+    </StackPanel>
+</dialogs:DialogBase>

--- a/Views/Dialogs/AddProductDialog.xaml.cs
+++ b/Views/Dialogs/AddProductDialog.xaml.cs
@@ -1,19 +1,13 @@
-﻿using System;
+using System;
 using System.Windows;
 
 namespace ToxicBizBuddyWPF.Views.Dialogs
 {
-    public partial class AddProductDialog : Window
+    public partial class AddProductDialog : DialogBase
     {
         public AddProductDialog()
         {
             InitializeComponent();
-        }
-
-        private void Close_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = false;
-            Close();
         }
 
         private void Save_Click(object sender, RoutedEventArgs e)

--- a/Views/Dialogs/AddProviderDialog.xaml
+++ b/Views/Dialogs/AddProviderDialog.xaml
@@ -1,160 +1,127 @@
-﻿<Window x:Class="ToxicBizBuddyWPF.Views.Dialogs.AddProviderDialog"
+<dialogs:DialogBase x:Class="ToxicBizBuddyWPF.Views.Dialogs.AddProviderDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="clr-namespace:ToxicBizBuddyWPF.Views.Dialogs"
         Title="Nuevo proveedor"
-        WindowStyle="None"
-        ResizeMode="NoResize"
-        AllowsTransparency="True"
-        Background="Transparent"
-        WindowStartupLocation="CenterOwner"
-        WindowState="Maximized"
-        ShowInTaskbar="False"
-        Topmost="True">
+        CardWidth="640">
+    <StackPanel>
+        <!-- Formulario -->
+        <Grid Margin="0,8,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <!-- Nombre / Razón social -->
+                <RowDefinition Height="Auto"/>
+                <!-- Contacto / Teléfono -->
+                <RowDefinition Height="Auto"/>
+                <!-- Email / CUIT -->
+                <RowDefinition Height="Auto"/>
+                <!-- Dirección / Localidad -->
+                <RowDefinition Height="Auto"/>
+                <!-- Provincia / Estado -->
+                <RowDefinition Height="Auto"/>
+                <!-- Condición de pago / Límite de crédito -->
+                <RowDefinition Height="Auto"/>
+                <!-- Descuento / Observaciones -->
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
 
-    <!-- Overlay -->
-    <Grid Background="#80000000">
-        <!-- Card centrada -->
-        <Border Style="{StaticResource CardStyle}" Width="640" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <StackPanel>
-
-                <!-- Header (título + cerrar) -->
-                <Grid Margin="0,0,0,12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Text="Agregar proveedor" Style="{StaticResource H1}" FontSize="20" VerticalAlignment="Center"/>
-                    <Button Grid.Column="1"
-                            Content="✕"
-                            Width="34" Height="34"
-                            Background="Transparent"
-                            BorderThickness="0"
-                            Cursor="Hand"
-                            HorizontalAlignment="Right"
-                            ToolTip="Cerrar"
-                            Click="Close_Click"/>
-                </Grid>
-
-                <!-- Formulario -->
-                <Grid Margin="0,8,0,0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <!-- Nombre / Razón social -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Contacto / Teléfono -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Email / CUIT -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Dirección / Localidad -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Provincia / Estado -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Condición de pago / Límite de crédito -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Descuento / Observaciones -->
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <!-- Nombre / Razón social -->
-                    <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,10">
-                        <TextBlock Text="Nombre / Razón social" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Nombre del proveedor"/>
-                    </StackPanel>
-
-                    <!-- Contacto -->
-                    <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Contacto" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Persona de contacto"/>
-                    </StackPanel>
-
-                    <!-- Teléfono -->
-                    <StackPanel Grid.Row="1" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Teléfono" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Teléfono del proveedor"/>
-                    </StackPanel>
-
-                    <!-- Email -->
-                    <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Email" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Correo electrónico"/>
-                    </StackPanel>
-
-                    <!-- CUIT (opcional) -->
-                    <StackPanel Grid.Row="2" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="CUIT (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="CUIT del proveedor"/>
-                    </StackPanel>
-
-                    <!-- Dirección -->
-                    <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Dirección" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Calle y número"/>
-                    </StackPanel>
-
-                    <!-- Localidad -->
-                    <StackPanel Grid.Row="3" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Localidad" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Localidad / Ciudad"/>
-                    </StackPanel>
-
-                    <!-- Provincia -->
-                    <StackPanel Grid.Row="4" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Provincia" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Provincia"/>
-                    </StackPanel>
-
-                    <!-- Estado -->
-                    <StackPanel Grid.Row="4" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Estado" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
-                            <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2" ToolTip="Estado del proveedor">
-                                <ComboBoxItem Content="Activo" IsSelected="True"/>
-                                <ComboBoxItem Content="Inactivo"/>
-                            </ComboBox>
-                        </Border>
-                    </StackPanel>
-
-                    <!-- Condición de pago -->
-                    <StackPanel Grid.Row="5" Grid.Column="0" Margin="0,0,8,10">
-                        <TextBlock Text="Condición de pago" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
-                            <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2" ToolTip="Condición de pago">
-                                <ComboBoxItem Content="Contado" IsSelected="True"/>
-                                <ComboBoxItem Content="Cuenta corriente"/>
-                                <ComboBoxItem Content="Transferencia"/>
-                            </ComboBox>
-                        </Border>
-                    </StackPanel>
-
-                    <!-- Límite de crédito -->
-                    <StackPanel Grid.Row="5" Grid.Column="1" Margin="8,0,0,10">
-                        <TextBlock Text="Límite de crédito (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Monto de crédito"/>
-                    </StackPanel>
-
-                    <!-- Descuento -->
-                    <StackPanel Grid.Row="6" Grid.Column="0" Margin="0,0,8,0">
-                        <TextBlock Text="Descuento (%) (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Porcentaje de descuento"/>
-                    </StackPanel>
-
-                    <!-- Observaciones -->
-                    <StackPanel Grid.Row="6" Grid.Column="1" Margin="8,0,0,0">
-                        <TextBlock Text="Observaciones (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
-                        <TextBox Style="{StaticResource InputText}" ToolTip="Notas u observaciones" AcceptsReturn="True" Height="80" TextWrapping="Wrap"/>
-                    </StackPanel>
-                </Grid>
-
-                <!-- Footer -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
-                    <Button Content="Cancelar" Style="{StaticResource BtnGhost}" Click="Close_Click"/>
-                    <Button Content="Guardar" Style="{StaticResource BtnPrimary}" Margin="12,0,0,0" Click="Close_Click"/>
-                </StackPanel>
-
+            <!-- Nombre / Razón social -->
+            <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,10">
+                <TextBlock Text="Nombre / Razón social" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Nombre del proveedor"/>
             </StackPanel>
-        </Border>
-    </Grid>
-</Window>
+
+            <!-- Contacto -->
+            <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Contacto" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Persona de contacto"/>
+            </StackPanel>
+
+            <!-- Teléfono -->
+            <StackPanel Grid.Row="1" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Teléfono" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Teléfono del proveedor"/>
+            </StackPanel>
+
+            <!-- Email -->
+            <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Email" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Correo electrónico"/>
+            </StackPanel>
+
+            <!-- CUIT (opcional) -->
+            <StackPanel Grid.Row="2" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="CUIT (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="CUIT del proveedor"/>
+            </StackPanel>
+
+            <!-- Dirección -->
+            <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Dirección" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Calle y número"/>
+            </StackPanel>
+
+            <!-- Localidad -->
+            <StackPanel Grid.Row="3" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Localidad" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Localidad / Ciudad"/>
+            </StackPanel>
+
+            <!-- Provincia -->
+            <StackPanel Grid.Row="4" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Provincia" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Provincia"/>
+            </StackPanel>
+
+            <!-- Estado -->
+            <StackPanel Grid.Row="4" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Estado" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
+                    <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2" ToolTip="Estado del proveedor">
+                        <ComboBoxItem Content="Activo" IsSelected="True"/>
+                        <ComboBoxItem Content="Inactivo"/>
+                    </ComboBox>
+                </Border>
+            </StackPanel>
+
+            <!-- Condición de pago -->
+            <StackPanel Grid.Row="5" Grid.Column="0" Margin="0,0,8,10">
+                <TextBlock Text="Condición de pago" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <Border Background="White" BorderBrush="{StaticResource Slate200Brush}" BorderThickness="1" CornerRadius="8" Padding="4">
+                    <ComboBox BorderThickness="0" Background="Transparent" Padding="4,2" ToolTip="Condición de pago">
+                        <ComboBoxItem Content="Contado" IsSelected="True"/>
+                        <ComboBoxItem Content="Cuenta corriente"/>
+                        <ComboBoxItem Content="Transferencia"/>
+                    </ComboBox>
+                </Border>
+            </StackPanel>
+
+            <!-- Límite de crédito -->
+            <StackPanel Grid.Row="5" Grid.Column="1" Margin="8,0,0,10">
+                <TextBlock Text="Límite de crédito (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Monto de crédito"/>
+            </StackPanel>
+
+            <!-- Descuento -->
+            <StackPanel Grid.Row="6" Grid.Column="0" Margin="0,0,8,0">
+                <TextBlock Text="Descuento (%) (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Porcentaje de descuento"/>
+            </StackPanel>
+
+            <!-- Observaciones -->
+            <StackPanel Grid.Row="6" Grid.Column="1" Margin="8,0,0,0">
+                <TextBlock Text="Observaciones (opcional)" Style="{StaticResource Subtle}" Margin="0,0,0,4"/>
+                <TextBox Style="{StaticResource InputText}" ToolTip="Notas u observaciones" AcceptsReturn="True" Height="80" TextWrapping="Wrap"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Footer -->
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
+            <Button Content="Cancelar" Style="{StaticResource BtnGhost}" Click="Close_Click"/>
+            <Button Content="Guardar" Style="{StaticResource BtnPrimary}" Margin="12,0,0,0" Click="Save_Click"/>
+        </StackPanel>
+    </StackPanel>
+</dialogs:DialogBase>

--- a/Views/Dialogs/AddProviderDialog.xaml.cs
+++ b/Views/Dialogs/AddProviderDialog.xaml.cs
@@ -1,17 +1,16 @@
-﻿using System.Windows;
+using System.Windows;
 
 namespace ToxicBizBuddyWPF.Views.Dialogs
 {
-    public partial class AddProviderDialog : Window
+    public partial class AddProviderDialog : DialogBase
     {
         public AddProviderDialog()
         {
             InitializeComponent();
         }
 
-        private void Close_Click(object sender, RoutedEventArgs e)
+        private void Save_Click(object sender, RoutedEventArgs e)
         {
-            // Solo visual por ahora
             DialogResult = true; // o false si querés distinguir Cancelar
             Close();
         }

--- a/Views/Dialogs/ConfirmDialog.xaml
+++ b/Views/Dialogs/ConfirmDialog.xaml
@@ -1,47 +1,20 @@
-﻿<Window x:Class="ToxicBizBuddyWPF.Views.Dialogs.ConfirmDialog"
+<dialogs:DialogBase x:Class="ToxicBizBuddyWPF.Views.Dialogs.ConfirmDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Confirmar"
-        WindowStyle="None"
-        ResizeMode="NoResize"
-        AllowsTransparency="True"
-        Background="Transparent"
-        WindowStartupLocation="CenterOwner"
-        WindowState="Maximized"
-        ShowInTaskbar="False"
-        Topmost="True">
-    <Grid Background="#80000000">
-        <Border Style="{StaticResource CardStyle}" Width="440" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <StackPanel>
-                <!-- Header -->
-                <Grid Margin="0,0,0,12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Text="¿Eliminar elemento?" Style="{StaticResource H1}" FontSize="20" VerticalAlignment="Center"/>
-                    <Button Grid.Column="1"
-                  Content="✕"
-                  Width="34" Height="34"
-                  Background="Transparent"
-                  BorderThickness="0"
-                  Cursor="Hand"
-                  HorizontalAlignment="Right"
-                  Click="Close_Click"/>
-                </Grid>
-
-                <!-- Mensaje -->
-                <TextBlock Text="Esta acción no se puede deshacer."
+        xmlns:dialogs="clr-namespace:ToxicBizBuddyWPF.Views.Dialogs"
+        Title="¿Eliminar elemento?"
+        CardWidth="440">
+    <StackPanel>
+        <!-- Mensaje -->
+        <TextBlock Text="Esta acción no se puede deshacer."
                    Style="{StaticResource Subtle}" Margin="0,0,0,8"/>
-                <TextBlock Text="Se eliminará el registro seleccionado."
+        <TextBlock Text="Se eliminará el registro seleccionado."
                    Style="{StaticResource Subtle}" />
 
-                <!-- Footer -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
-                    <Button Content="Cancelar" Style="{StaticResource BtnGhost}" Click="Cancel_Click"/>
-                    <Button Content="Eliminar" Style="{StaticResource BtnDestructive}" Margin="12,0,0,0" Click="Confirm_Click"/>
-                </StackPanel>
-            </StackPanel>
-        </Border>
-    </Grid>
-</Window>
+        <!-- Footer -->
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
+            <Button Content="Cancelar" Style="{StaticResource BtnGhost}" Click="Close_Click"/>
+            <Button Content="Eliminar" Style="{StaticResource BtnDestructive}" Margin="12,0,0,0" Click="Confirm_Click"/>
+        </StackPanel>
+    </StackPanel>
+</dialogs:DialogBase>

--- a/Views/Dialogs/ConfirmDialog.xaml.cs
+++ b/Views/Dialogs/ConfirmDialog.xaml.cs
@@ -1,26 +1,12 @@
-﻿using System.Windows;
+using System.Windows;
 
 namespace ToxicBizBuddyWPF.Views.Dialogs
 {
-    public partial class ConfirmDialog : Window
+    public partial class ConfirmDialog : DialogBase
     {
         public ConfirmDialog()
         {
             InitializeComponent();
-        }
-
-        private void Close_Click(object sender, RoutedEventArgs e)
-        {
-            // Cerrar con Cancelar (false)
-            DialogResult = false;
-            Close();
-        }
-
-        private void Cancel_Click(object sender, RoutedEventArgs e)
-        {
-            // Botón "Cancelar"
-            DialogResult = false;
-            Close();
         }
 
         private void Confirm_Click(object sender, RoutedEventArgs e)

--- a/Views/Dialogs/DialogBase.xaml
+++ b/Views/Dialogs/DialogBase.xaml
@@ -1,0 +1,36 @@
+<Window x:Class="ToxicBizBuddyWPF.Views.Dialogs.DialogBase"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStartupLocation="CenterOwner"
+        WindowState="Maximized"
+        ShowInTaskbar="False"
+        Topmost="True">
+    <Grid Background="#80000000">
+        <Border Style="{StaticResource CardStyle}" Width="{Binding CardWidth, RelativeSource={RelativeSource AncestorType=Window}}" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <StackPanel>
+                <!-- Header -->
+                <Grid Margin="0,0,0,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" Style="{StaticResource H1}" FontSize="20" VerticalAlignment="Center"/>
+                    <Button Grid.Column="1"
+                            Content="✕"
+                            Width="34" Height="34"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Cursor="Hand"
+                            HorizontalAlignment="Right"
+                            ToolTip="Cerrar"
+                            Click="Close_Click"/>
+                </Grid>
+                <ContentPresenter/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/Views/Dialogs/DialogBase.xaml.cs
+++ b/Views/Dialogs/DialogBase.xaml.cs
@@ -1,0 +1,27 @@
+using System.Windows;
+
+namespace ToxicBizBuddyWPF.Views.Dialogs
+{
+    public partial class DialogBase : Window
+    {
+        public DialogBase()
+        {
+            InitializeComponent();
+        }
+
+        public static readonly DependencyProperty CardWidthProperty =
+            DependencyProperty.Register("CardWidth", typeof(double), typeof(DialogBase), new PropertyMetadata(640.0));
+
+        public double CardWidth
+        {
+            get => (double)GetValue(CardWidthProperty);
+            set => SetValue(CardWidthProperty, value);
+        }
+
+        public void Close_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `DialogBase` window with overlay, card container and close button
- update AddClientDialog, AddProductDialog, AddProviderDialog and ConfirmDialog to inherit from the base and provide only specific content

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b849b1dd9483278b68f984fdbd4668