### PR TITLE
Specify assembly for ItemsToStringConverter

### DIFF
--- a/Views/OrdersPage.xaml
+++ b/Views/OrdersPage.xaml
@@ -2,7 +2,7 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components"
-      xmlns:conv="clr-namespace:ToxicBizBuddyWPF.Converters"
+      xmlns:conv="clr-namespace:ToxicBizBuddyWPF.Converters;assembly=ToxicBizBuddyWPF"
       Title="Gestión de Pedidos">
 
     <Page.Resources>


### PR DESCRIPTION
## Summary
- include assembly name in OrdersPage ItemsToStringConverter namespace

## Testing
- `dotnet msbuild -t:Compile` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b854856f188327a6e467980437225e