### PR TITLE
Reference components assembly in view XAML

### DIFF
--- a/Views/ClientsPage.xaml
+++ b/Views/ClientsPage.xaml
@@ -1,7 +1,7 @@
 ﻿<Page x:Class="ToxicBizBuddyWPF.Views.ClientsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components"
+      xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components;assembly=ToxicBizBuddyWPF"
 
 
 

--- a/Views/DashboardPage.xaml
+++ b/Views/DashboardPage.xaml
@@ -1,7 +1,7 @@
 ﻿<Page x:Class="ToxicBizBuddyWPF.Views.DashboardPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components"
+      xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components;assembly=ToxicBizBuddyWPF"
       Title="DashboardPage">
     <components:PageWrapper>
         <!-- margen interno para que nada quede pegado a los bordes -->

--- a/Views/OrdersPage.xaml
+++ b/Views/OrdersPage.xaml
@@ -1,7 +1,7 @@
 ﻿<Page x:Class="ToxicBizBuddyWPF.Views.OrdersPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components"
+      xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components;assembly=ToxicBizBuddyWPF"
       xmlns:conv="clr-namespace:ToxicBizBuddyWPF.Converters;assembly=ToxicBizBuddyWPF"
       Title="Gestión de Pedidos">
 

--- a/Views/ProductsPage.xaml
+++ b/Views/ProductsPage.xaml
@@ -1,7 +1,7 @@
 ﻿<Page x:Class="ToxicBizBuddyWPF.Views.ProductsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components"
+      xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components;assembly=ToxicBizBuddyWPF"
       Title="ProductsPage">
 
     <!-- Estilos locales de esta página -->

--- a/Views/ProvidersPage.xaml
+++ b/Views/ProvidersPage.xaml
@@ -1,7 +1,7 @@
 ﻿<Page x:Class="ToxicBizBuddyWPF.Views.ProvidersPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components"
+      xmlns:components="clr-namespace:ToxicBizBuddyWPF.Components;assembly=ToxicBizBuddyWPF"
 
 
       Title="Proveedores">


### PR DESCRIPTION
## Summary
- add assembly reference for components namespace in view XAML files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b85af7dc388327a1ce32020f577c9d