### PR TITLE
Simplify collection setup and use primary constructor

### DIFF
--- a/Views/Dialogs/DialogBase.cs
+++ b/Views/Dialogs/DialogBase.cs
@@ -21,22 +21,6 @@ namespace ToxicBizBuddyWPF.Views.Dialogs
             ShowInTaskbar = false;
             Topmost = true;
 
-            _root = new Grid { Background = new SolidColorBrush(Color.FromArgb(128, 0, 0, 0)) };
-
-            var border = new Border
-            {
-                Style = (Style)Application.Current.FindResource("CardStyle"),
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center
-            };
-            border.SetBinding(Border.WidthProperty, new Binding(nameof(CardWidth)) { Source = this });
-
-            var stack = new StackPanel();
-
-            var header = new Grid { Margin = new Thickness(0, 0, 0, 12) };
-            header.ColumnDefinitions.Add(new ColumnDefinition());
-            header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
             var title = new TextBlock
             {
                 Style = (Style)Application.Current.FindResource("H1"),
@@ -59,16 +43,46 @@ namespace ToxicBizBuddyWPF.Views.Dialogs
             closeBtn.Click += Close_Click;
             Grid.SetColumn(closeBtn, 1);
 
-            header.Children.Add(title);
-            header.Children.Add(closeBtn);
-
             _contentPresenter = new ContentPresenter();
 
-            stack.Children.Add(header);
-            stack.Children.Add(_contentPresenter);
+            var header = new Grid
+            {
+                Margin = new Thickness(0, 0, 0, 12),
+                ColumnDefinitions =
+                {
+                    new ColumnDefinition(),
+                    new ColumnDefinition { Width = GridLength.Auto }
+                },
+                Children =
+                {
+                    title,
+                    closeBtn
+                }
+            };
 
-            border.Child = stack;
-            _root.Children.Add(border);
+            var stack = new StackPanel
+            {
+                Children =
+                {
+                    header,
+                    _contentPresenter
+                }
+            };
+
+            var border = new Border
+            {
+                Style = (Style)Application.Current.FindResource("CardStyle"),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Child = stack
+            };
+            border.SetBinding(Border.WidthProperty, new Binding(nameof(CardWidth)) { Source = this });
+
+            _root = new Grid
+            {
+                Background = new SolidColorBrush(Color.FromArgb(128, 0, 0, 0)),
+                Children = { border }
+            };
             base.Content = _root;
         }
 

--- a/Views/OrdersPage.xaml.cs
+++ b/Views/OrdersPage.xaml.cs
@@ -77,23 +77,13 @@ namespace ToxicBizBuddyWPF.Views
         }
     }
 
-    public sealed class OrderRow
+    public sealed class OrderRow(string pedido, string cliente, DateTime fecha, int items, decimal total, string estado)
     {
-        public string Pedido { get; }
-        public string Cliente { get; }
-        public DateTime Fecha { get; }
-        public int Items { get; }
-        public decimal Total { get; }
-        public string Estado { get; }
-
-        public OrderRow(string pedido, string cliente, DateTime fecha, int items, decimal total, string estado)
-        {
-            Pedido = pedido;
-            Cliente = cliente;
-            Fecha = fecha;
-            Items = items;
-            Total = total;
-            Estado = estado; // "Completado" | "Pendiente" | "Cancelado"
-        }
+        public string Pedido { get; } = pedido;
+        public string Cliente { get; } = cliente;
+        public DateTime Fecha { get; } = fecha;
+        public int Items { get; } = items;
+        public decimal Total { get; } = total;
+        public string Estado { get; } = estado; // "Completado" | "Pendiente" | "Cancelado"
     }
 }


### PR DESCRIPTION
## Summary
- streamline dialog layout construction with collection initializers
- use C# 12 primary constructor for OrderRow

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b85d8feccc83279eb460e69ddcc37d